### PR TITLE
Fixes router.migrator mock skipping, fixes deprecation wrarnings

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -1,5 +1,5 @@
 import peewee as pw
-from collections import Hashable, OrderedDict
+import collections
 from playhouse.reflection import Column as VanilaColumn
 
 
@@ -137,8 +137,8 @@ def diff_many(models1, models2, migrator=None, reverse=False):
         models1 = reversed(models1)
         models2 = reversed(models2)
 
-    models1 = OrderedDict([(m._meta.name, m) for m in models1])
-    models2 = OrderedDict([(m._meta.name, m) for m in models2])
+    models1 = collections.OrderedDict([(m._meta.name, m) for m in models1])
+    models2 = collections.OrderedDict([(m._meta.name, m) for m in models2])
 
     changes = []
 
@@ -223,7 +223,8 @@ def compare_fields(field1, field2, **kwargs):
 def field_to_params(field, **kwargs):
     params = FIELD_TO_PARAMS.get(type(field), lambda f: {})(field)
     if field.default is not None and \
-            not callable(field.default) and isinstance(field.default, Hashable):
+            not callable(field.default) \
+            and isinstance(field.default, collections.Hashable):
         params['default'] = field.default
 
     params['index'] = field.index and not field.unique, field.unique

--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -137,7 +137,7 @@ class BaseRouter(object):
             migrate, rollback = self.read(name)
             if fake:
                 with mock.patch('peewee.Model.select'):
-                    with mock.patch('peewee.Query._execute'):
+                    with mock.patch('peewee.Database.execute_sql'):
                         migrate(migrator, self.database, fake=fake)
 
                 if force:


### PR DESCRIPTION
When any migrate/rollback command done it router calls self.migrator, which is supposed to call all done migrations with fake flag.
But current mock is not working, and it causes dangerous operations to run every time (happenned to real database). 

The mocking changed to `with mock.patch('peewee.Database.execute_sql')` and in fact I noticed when edited it that this mock is used in https://github.com/spumer/peewee_migrate2/blob/develop/tests/test_router.py#L36 . So I guess the change is correct. 

Also got some deprecation warnings during running tests, so adjusted import a bit to make interpreter happy

```Fixes "DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working"```