### PR TITLE
Fix fake run migration with creating entites within

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -136,8 +136,11 @@ class BaseRouter(object):
         try:
             migrate, rollback = self.read(name)
             if fake:
+                cursor_mock = mock.Mock()
+                cursor_mock.fetch_one.return_value = None
                 with mock.patch('peewee.Model.select'):
-                    with mock.patch('peewee.Database.execute_sql'):
+                    with mock.patch('peewee.Database.execute_sql',
+                                    return_value=cursor_mock):
                         migrate(migrator, self.database, fake=fake)
 
                 if force:


### PR DESCRIPTION
When already applied migration contains insert queries, migrator stuck
in the endless loop. Affected postgresql, perhaps another databases too.

This patch adds None as a return value to mocked cursor fetch_one
method.

Here is a traceback after interupting executing of the `run_one` with `fake=True`
```
 File "/usr/local/lib/python3.7/site-packages/peewee.py", line 6292, in create
    inst.save(force_insert=True)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 6499, in save
    pk = self.insert(**field_dict).execute()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 1886, in inner
    return method(self, database, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 1957, in execute
    return self._execute(database)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 2707, in _execute
    return super(Insert, self)._execute(database)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 2443, in _execute
    return self.handle_result(database, cursor)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 2716, in handle_result
    return database.last_insert_id(cursor, self._query_type)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 3757, in last_insert_id
    return cursor if query_type != Insert.SIMPLE else cursor[0][0]
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4225, in __getitem__
    self.fill_cache(item if item > 0 else 0)
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4273, in fill_cache
    iterator.next()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4329, in next
    self.cursor_wrapper.iterate()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4239, in iterate
    row = self.cursor.fetchone()
  File "/usr/local/lib/python3.7/unittest/mock.py", line 1016, in __call__
    return _mock_self._mock_call(*args, **kwargs)
  File "/usr/local/lib/python3.7/unittest/mock.py", line 1025, in _mock_call
    _call = _Call((args, kwargs), two=True)
  File "/usr/local/lib/python3.7/unittest/mock.py", line 2067, in __new__
    return tuple.__new__(cls, (args, kwargs))
```
Here `cursor` is a `CursorWrapper` instance with mocked `cursor` property (return value from the pathched `peewee.Database.execute_sql`)

```
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 3757, in last_insert_id
    return cursor if query_type != Insert.SIMPLE else cursor[0][0]
```

As far as `cursor` is a mock here - it never returns a `None` and `fill_cache` function will never ends.
```
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4273, in fill_cache
    iterator.next()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4329, in next
    self.cursor_wrapper.iterate()
  File "/usr/local/lib/python3.7/site-packages/peewee.py", line 4239, in iterate
    row = self.cursor.fetchone()
```

Adding None as a return value for the `cursor.fetchone` allows to stop iteration.