### PR TITLE
Feature: database schema select

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ Create migration: ::
         --auto-source           TEXT  Set to python module path for changes autoscan (e.g. 'package.models'). Current directory will be recursively scanned by default.
         --database              TEXT  Database connection
         --directory             TEXT  Directory where migrations are stored
+        --schema                TEXT  Database schema
         -v, --verbose
         --help                        Show this message and exit.
 
@@ -113,11 +114,12 @@ Run migrations: ::
         Run migrations.
 
     Options:
-        --name TEXT       Select migration
-        --database TEXT   Database connection
-        --directory TEXT  Directory where migrations are stored
+        --name                  TEXT  Select migration
+        --database              TEXT  Database connection
+        --directory             TEXT  Directory where migrations are stored
+        --schema                TEXT  Database schema
         -v, --verbose
-        --help            Show this message and exit.
+        --help                        Show this message and exit.
 
 Auto create migration: ::
 
@@ -140,6 +142,7 @@ Auto create migration: ::
                           scanned by default.
         --database TEXT     Database connection
         --directory TEXT    Directory where migrations are stored
+        --schema                TEXT  Database schema
         -v, --verbose
         --help              Show this message and exit.
 

--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -65,7 +65,7 @@ class BaseRouter(object):
     @cached_property
     def migrator(self):
         """Create migrator and setup it with fake migrations."""
-        migrator = Migrator(self.database)
+        migrator = Migrator(self.database, self.schema)
         for name in self.done:
             self.run_one(name, migrator)
         return migrator

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -70,4 +70,17 @@ def test_router_compile(tmpdir):
         content = f.read()
         assert 'SQL = pw.SQL' in content
 
+
+def test_router_schema(tmpdir):
+    from peewee_migrate.cli import get_router
+
+    schema_name = 'test'
+    migrations = tmpdir.mkdir('migrations')
+
+    with mock.patch('peewee_migrate.router.BaseRouter.done'):
+        router = get_router(str(migrations), 'postgres:///fake', schema=schema_name)
+
+        assert router.schema == schema_name
+        assert router.migrator.schema == schema_name
+
 # pylama:ignore=W0621


### PR DESCRIPTION
Add ability to choose database schema for migrations through cli parameter (`--schema`).

Basically, it substitutes a model's meta parameter with the selected schema passed by cli parameter or by `conf.py` and adds schema selection query before migration runs.