### PR TITLE
fix Hashable import for python 3.10.1

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -224,7 +224,7 @@ def field_to_params(field, **kwargs):
     params = FIELD_TO_PARAMS.get(type(field), lambda f: {})(field)
     if field.default is not None and \
             not callable(field.default) \
-            and isinstance(field.default, collections.Hashable):
+            and isinstance(field.default, collections.abc.Hashable):
         params['default'] = field.default
 
     params['index'] = field.index and not field.unique, field.unique


### PR DESCRIPTION
I got an error for python 3.10.1 because it was unable to import Hashable from collections module. It is because of
```bash
gorshkov_n@asus:~/projects/seahorse$ python
Python 3.8.12 (default, Dec 16 2021, 17:25:25) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Hashable
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```
I've fixed it :)