### PR TITLE
fix sqlite drop_columns for fk

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -104,6 +104,10 @@ class SqliteMigrator(SchemaMigrator, SqM):
     def alter_change_column(self, table, column, field):
         """Support change columns."""
         return self._update_column(table, column, lambda a, b: b)
+    
+    def drop_column(self, table, column_name, cascade=True, legacy=True, **kwargs):
+        """drop_column will not work for FK so we should use the legacy version"""
+        return super(SqliteMigrator, self).drop_column(table, column_name, cascade, legacy, **kwargs)
 
 
 def get_model(method):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,4 +3,3 @@
 
 pytest==8.3.5
 psycopg2-binary>=2.8.1
-peewee<=3.16.2


### PR DESCRIPTION
Насколько я понял в старых версиях sqlite до 3.35 не было  возможности делать DROP COLUMN и удаление колонок делалось делалось через создание временной таблицы. В peewee<=3.16.2 этот механизм использовался по дефолту, в версиях старше идёт проверка на версию sqlite и если она больше 3.35, то используется команда DROP COLMUN. Однако sqlite не поддерживает drop column для FK колонок. В общем, сделал использование legacy версии для любого типа колонок. #52